### PR TITLE
WDM-6: added verbose option to block debug info from being shown in admin dash

### DIFF
--- a/src/Admins/AkeneoAdmin.php
+++ b/src/Admins/AkeneoAdmin.php
@@ -54,6 +54,7 @@ class AkeneoAdmin extends ModelAdmin
     {
         /** @var  AkeneoImport $import */
         $import = Injector::inst()->get('AkeneoImport');
+        $import->setVerbose(false);
         $import->run([]);
 
         Controller::curr()->getResponse()->addHeader('X-Status', 'Synced');

--- a/src/Imports/AkeneoImport.php
+++ b/src/Imports/AkeneoImport.php
@@ -55,6 +55,8 @@ class AkeneoImport
     private array $productModelsAssociations = [];
     private array $productsAssociations = [];
 
+    private bool $verbose = true;
+
     private AkeneoApi $akeneoApi;
 
     private array $associationMapping = [
@@ -454,6 +456,18 @@ class AkeneoImport
 
     protected function output($message)
     {
-        echo date('d-m-Y H:i:s') . ' : ' . $message . "\n";
+        if($this->verbose) {
+            echo date('d-m-Y H:i:s') . ' : ' . $message . "\n";
+        }
+    }
+
+    public function setVerbose(bool $verbose) : bool
+    {
+        return $this->verbose = $verbose;
+    }
+
+    public function getVerbose() : bool
+    {
+        return $this->verbose;
     }
 }


### PR DESCRIPTION
Currently the default for verbose is set to `true`