### PR TITLE
Shrink the filename lenght of downloaded files.

### DIFF
--- a/src/Models/ProductMediaFile.php
+++ b/src/Models/ProductMediaFile.php
@@ -73,7 +73,7 @@ class ProductMediaFile extends DataObject
 
         /** @var File $file */
         $file = new $mediaFileClass();
-        $file->setFromString($content, sprintf('%s_%s', substr(hash('sha256', $data['code']), 0, 8), $data['original_filename']));
+        $file->setFromString($content, sprintf('%s_%s', crc32($content), $data['original_filename']));
 
         $type = $file->appCategory();
 

--- a/src/Models/ProductMediaFile.php
+++ b/src/Models/ProductMediaFile.php
@@ -73,7 +73,7 @@ class ProductMediaFile extends DataObject
 
         /** @var File $file */
         $file = new $mediaFileClass();
-        $file->setFromString($content, sprintf('%s_%s', base64_encode($data['code']), $data['original_filename']));
+        $file->setFromString($content, sprintf('%s_%s', substr(hash('sha256', $data['code']), 0, 8), $data['original_filename']));
 
         $type = $file->appCategory();
 


### PR DESCRIPTION
Using `base64_encode($data['code'])` to generate a unique prefix for a filename might casue excessively long filenames which might hit the filesystem limits.

`MS9lL2IvNi8xZWI2MjM2OWEwZGJlYWIxYzZjNDY4NzdlZGIyZTY4ODEwOWE1MGQyXzE1MjAwMF9fX0JlZHJpamZzdmVyYmFuZGRvb3NfQkhWX21vZHVsYWlyX21ldF93YW5kaG91ZGVyX1YxLnBuZw_152000-Bedrijfsverbanddoos-BHV-modulair-met-wandhouder-V1__FocusFillWyIwLjAwIiwiMC4wMCIsMzUyLDI2NF0.png.webp`

Since we only use this to ensure some kind of uniqueness to prevent filename conflicts, it is sufficient to use the first 8 chars of the sha256 hash of the code string.